### PR TITLE
feat: add docker healthchecks, java records for dtos and pix key registration flow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM gradle:9.3.0-jdk21-jammy AS build
+WORKDIR /app
+
+COPY build.gradle settings.gradle ./
+COPY gradle.properties* ./
+COPY gradle ./gradle
+
+RUN gradle dependencies --no-daemon || true
+
+COPY src ./src
+RUN gradle build --no-daemon -x test
+
+FROM eclipse-temurin:21-jre-jammy
+WORKDIR /app
+COPY --from=build /app/build/libs/*.jar app.jar
+
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,11 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'
+    implementation 'org.mapstruct:mapstruct:1.6.3'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'jakarta.validation:jakarta.validation-api:3.1.1'
+
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-flyway'
     implementation 'org.springframework.boot:spring-boot-starter-kafka'
@@ -33,6 +38,10 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'
+
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
+    annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-flyway-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-kafka-test'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,28 @@
 services:
+  app:
+    image: fastpay:latest
+    networks:
+      - fastpay-network
+    build:
+      context: .
+    container_name: fastpay-app
+    restart: always
+    ports:
+      - "8080:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+    env_file:
+      - .env
+    healthcheck:
+      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080/actuator/health || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
   postgres:
     image: postgres:18-alpine
     container_name: fastpay-postgres
@@ -11,6 +35,11 @@ services:
       - fastpay_pgdata:/var/lib/postgresql/data
     networks:
       - fastpay-network
+    healthcheck:
+      test: [ "CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   kafka:
     image: confluentinc/cp-kafka:8.0.3
@@ -24,6 +53,12 @@ services:
       - fastpay_kafka_data:/var/lib/kafka/data
     networks:
       - fastpay-network
+    healthcheck:
+      test: [ "CMD", "kafka-topics", "--bootstrap-server", "localhost:9092", "--list" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
 
 networks:
   fastpay-network:

--- a/src/main/java/com/fastpay/application/service/RegisterPixKeyService.java
+++ b/src/main/java/com/fastpay/application/service/RegisterPixKeyService.java
@@ -1,4 +1,42 @@
 package com.fastpay.application.service;
 
-public class RegisterPixKeyService {
+
+import com.fastpay.domain.model.Account;
+import com.fastpay.domain.model.PixKey;
+import com.fastpay.domain.model.enums.KeyType;
+import com.fastpay.domain.port.in.RegisterPixKeyUseCase;
+import com.fastpay.domain.port.out.AccountDatabasePort;
+import com.fastpay.domain.port.out.PixKeyDatabasePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class RegisterPixKeyService implements RegisterPixKeyUseCase {
+
+    private final PixKeyDatabasePort pixKeyDatabasePort;
+    private final AccountDatabasePort accountDatabasePort;
+
+    @Override
+    public PixKey register(UUID accountId, KeyType type, String value) {
+        Account account = accountDatabasePort.findById(accountId)
+                .orElseThrow(() -> new IllegalArgumentException("Account not found for ID: " + accountId));
+
+        if (pixKeyDatabasePort.existsByValue(value)) {
+            throw new IllegalArgumentException("Pix key already exists: " + value);
+        }
+
+        PixKey pixKey = PixKey.builder()
+                .id(UUID.randomUUID())
+                .account(account)
+                .type(type)
+                .value(value)
+                .createdAt(Instant.now())
+                .build();
+
+        return pixKeyDatabasePort.save(pixKey);
+    }
 }

--- a/src/main/java/com/fastpay/domain/exception/KeyNotFoundException.java
+++ b/src/main/java/com/fastpay/domain/exception/KeyNotFoundException.java
@@ -1,4 +1,7 @@
 package com.fastpay.domain.exception;
 
-public class KeyNotFoundException {
+public class KeyNotFoundException extends RuntimeException {
+    public KeyNotFoundException(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/com/fastpay/domain/port/in/RegisterPixKeyUseCase.java
+++ b/src/main/java/com/fastpay/domain/port/in/RegisterPixKeyUseCase.java
@@ -1,4 +1,11 @@
 package com.fastpay.domain.port.in;
 
-public class RegisterPixKeyUseCase {
+import com.fastpay.domain.model.PixKey;
+import com.fastpay.domain.model.enums.KeyType;
+
+import java.util.UUID;
+
+public interface RegisterPixKeyUseCase {
+    PixKey register(UUID accountId, KeyType type, String value);
+
 }

--- a/src/main/java/com/fastpay/domain/port/out/AccountDatabasePort.java
+++ b/src/main/java/com/fastpay/domain/port/out/AccountDatabasePort.java
@@ -1,0 +1,12 @@
+package com.fastpay.domain.port.out;
+
+import com.fastpay.domain.model.Account;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface AccountDatabasePort {
+    Optional<Account> findById(UUID id);
+
+    Account update(Account account);
+}

--- a/src/main/java/com/fastpay/domain/port/out/PixKeyDatabasePort.java
+++ b/src/main/java/com/fastpay/domain/port/out/PixKeyDatabasePort.java
@@ -1,4 +1,13 @@
 package com.fastpay.domain.port.out;
 
-public class PixKeyDatabasePort {
+import com.fastpay.domain.model.PixKey;
+
+import java.util.Optional;
+
+public interface PixKeyDatabasePort {
+    PixKey save(PixKey pixKey);
+
+    boolean existsByValue(String value);
+
+    Optional<PixKey> findByValue(String value);
 }

--- a/src/main/java/com/fastpay/infra/persistence/postgres/adapter/AccountPostgresAdapter.java
+++ b/src/main/java/com/fastpay/infra/persistence/postgres/adapter/AccountPostgresAdapter.java
@@ -1,0 +1,29 @@
+package com.fastpay.infra.persistence.postgres.adapter;
+
+import com.fastpay.domain.model.Account;
+import com.fastpay.domain.port.out.AccountDatabasePort;
+import com.fastpay.infra.persistence.postgres.mapper.AccountDatabaseMapper;
+import com.fastpay.infra.persistence.postgres.repository.SpringDataAccountRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class AccountPostgresAdapter implements AccountDatabasePort {
+
+    private final SpringDataAccountRepository repository;
+    private final AccountDatabaseMapper mapper;
+
+    @Override
+    public Optional<Account> findById(UUID id) {
+        return repository.findById(id).map(mapper::toDomain);
+    }
+
+    @Override
+    public Account update(Account account) {
+        return mapper.toDomain(repository.save(mapper.toEntity(account)));
+    }
+}

--- a/src/main/java/com/fastpay/infra/persistence/postgres/adapter/PixKeyPostgresAdapter.java
+++ b/src/main/java/com/fastpay/infra/persistence/postgres/adapter/PixKeyPostgresAdapter.java
@@ -1,4 +1,37 @@
 package com.fastpay.infra.persistence.postgres.adapter;
 
-public class PixKeyPostgresAdapter {
+import com.fastpay.domain.model.PixKey;
+import com.fastpay.domain.port.out.PixKeyDatabasePort;
+import com.fastpay.infra.persistence.postgres.entity.PixKeyEntity;
+import com.fastpay.infra.persistence.postgres.mapper.PixKeyDatabaseMapper;
+import com.fastpay.infra.persistence.postgres.repository.SpringDataPixKeyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+
+@Component
+@RequiredArgsConstructor
+public class PixKeyPostgresAdapter implements PixKeyDatabasePort {
+
+    private final SpringDataPixKeyRepository repository;
+    private final PixKeyDatabaseMapper mapper;
+
+    @Override
+    public PixKey save(PixKey pixKey) {
+        PixKeyEntity entity = mapper.toEntity(pixKey);
+        PixKeyEntity savedEntity = repository.save(entity);
+        return mapper.toDomain(savedEntity);
+    }
+
+    @Override
+    public boolean existsByValue(String value) {
+        return repository.existsByValue(value);
+    }
+
+    @Override
+    public Optional<PixKey> findByValue(String value) {
+        return repository.findByValue(value).map(mapper::toDomain);
+    }
 }

--- a/src/main/java/com/fastpay/infra/persistence/postgres/entity/AccountEntity.java
+++ b/src/main/java/com/fastpay/infra/persistence/postgres/entity/AccountEntity.java
@@ -1,4 +1,29 @@
 package com.fastpay.infra.persistence.postgres.entity;
 
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "accounts")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class AccountEntity {
+
+    @Id
+    private UUID id;
+    private String agency;
+    private String number;
+
+    @Column(name = "balance_in_cents")
+    private Long balanceInCents;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private UserEntity user;
+
 }

--- a/src/main/java/com/fastpay/infra/persistence/postgres/entity/PixKeyEntity.java
+++ b/src/main/java/com/fastpay/infra/persistence/postgres/entity/PixKeyEntity.java
@@ -1,4 +1,36 @@
 package com.fastpay.infra.persistence.postgres.entity;
 
+import com.fastpay.domain.model.enums.KeyType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "pix_keys")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class PixKeyEntity {
+
+    @Id
+    private UUID id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private KeyType type;
+
+    @Column(unique = true, nullable = false)
+    private String value;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id")
+    private AccountEntity account;
+
 }

--- a/src/main/java/com/fastpay/infra/persistence/postgres/entity/UserEntity.java
+++ b/src/main/java/com/fastpay/infra/persistence/postgres/entity/UserEntity.java
@@ -1,4 +1,24 @@
 package com.fastpay.infra.persistence.postgres.entity;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.*;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "users")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class UserEntity {
+
+    @Id
+    private UUID id;
+    private String name;
+    private String document;
+
 }

--- a/src/main/java/com/fastpay/infra/persistence/postgres/mapper/AccountDatabaseMapper.java
+++ b/src/main/java/com/fastpay/infra/persistence/postgres/mapper/AccountDatabaseMapper.java
@@ -1,0 +1,12 @@
+package com.fastpay.infra.persistence.postgres.mapper;
+
+import com.fastpay.domain.model.Account;
+import com.fastpay.infra.persistence.postgres.entity.AccountEntity;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface AccountDatabaseMapper {
+    AccountEntity toEntity(Account domain);
+
+    Account toDomain(AccountEntity entity);
+}

--- a/src/main/java/com/fastpay/infra/persistence/postgres/mapper/PixKeyDatabaseMapper.java
+++ b/src/main/java/com/fastpay/infra/persistence/postgres/mapper/PixKeyDatabaseMapper.java
@@ -1,4 +1,12 @@
 package com.fastpay.infra.persistence.postgres.mapper;
 
-public class PixKeyDatabaseMapper {
+import com.fastpay.domain.model.PixKey;
+import com.fastpay.infra.persistence.postgres.entity.PixKeyEntity;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring", uses = {AccountDatabaseMapper.class})
+public interface PixKeyDatabaseMapper {
+    PixKeyEntity toEntity(PixKey domain);
+
+    PixKey toDomain(PixKeyEntity entity);
 }

--- a/src/main/java/com/fastpay/infra/persistence/postgres/repository/SpringDataAccountRepository.java
+++ b/src/main/java/com/fastpay/infra/persistence/postgres/repository/SpringDataAccountRepository.java
@@ -1,0 +1,9 @@
+package com.fastpay.infra.persistence.postgres.repository;
+
+import com.fastpay.infra.persistence.postgres.entity.AccountEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface SpringDataAccountRepository extends JpaRepository<AccountEntity, UUID> {
+}

--- a/src/main/java/com/fastpay/infra/persistence/postgres/repository/SpringDataPixKeyRepository.java
+++ b/src/main/java/com/fastpay/infra/persistence/postgres/repository/SpringDataPixKeyRepository.java
@@ -1,4 +1,13 @@
 package com.fastpay.infra.persistence.postgres.repository;
 
-public class SpringDataPixKeyRepository {
+import com.fastpay.infra.persistence.postgres.entity.PixKeyEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface SpringDataPixKeyRepository extends JpaRepository<PixKeyEntity, UUID> {
+    boolean existsByValue(String value);
+
+    Optional<PixKeyEntity> findByValue(String value);
 }

--- a/src/main/java/com/fastpay/presentation/controller/PixKeyController.java
+++ b/src/main/java/com/fastpay/presentation/controller/PixKeyController.java
@@ -1,4 +1,41 @@
 package com.fastpay.presentation.controller;
 
+import com.fastpay.domain.model.PixKey;
+import com.fastpay.domain.port.in.RegisterPixKeyUseCase;
+import com.fastpay.presentation.controller.request.PixKeyRequest;
+import com.fastpay.presentation.controller.response.PixKeyResponse;
+import com.fastpay.presentation.mapper.PixWebMapper;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/keys")
+@RequiredArgsConstructor
 public class PixKeyController {
+
+    private final RegisterPixKeyUseCase registerPixKeyUseCase;
+    private final PixWebMapper mapper;
+
+    @PostMapping
+    public ResponseEntity<PixKeyResponse> register(
+            @RequestBody @Valid PixKeyRequest request
+    ) {
+
+        PixKey registeredKey = registerPixKeyUseCase.register(
+                request.accountId(),
+                request.type(),
+                request.value()
+        );
+
+        PixKeyResponse response = mapper.toResponse(registeredKey);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
 }

--- a/src/main/java/com/fastpay/presentation/controller/request/PixKeyRequest.java
+++ b/src/main/java/com/fastpay/presentation/controller/request/PixKeyRequest.java
@@ -1,4 +1,20 @@
 package com.fastpay.presentation.controller.request;
 
-public class PixKeyRequest {
+import com.fastpay.domain.model.enums.KeyType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record PixKeyRequest(
+
+        @NotNull(message = "Account ID is mandatory")
+        UUID accountId,
+
+        @NotNull(message = "Key type is mandatory")
+        KeyType type,
+
+        @NotBlank(message = "Key value is mandatory")
+        String value
+) {
 }

--- a/src/main/java/com/fastpay/presentation/controller/response/PixKeyResponse.java
+++ b/src/main/java/com/fastpay/presentation/controller/response/PixKeyResponse.java
@@ -1,4 +1,14 @@
 package com.fastpay.presentation.controller.response;
 
-public class PixKeyResponse {
+import com.fastpay.domain.model.enums.KeyType;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record PixKeyResponse(
+        UUID id,
+        KeyType type,
+        String value,
+        Instant createdAt
+) {
 }

--- a/src/main/java/com/fastpay/presentation/mapper/PixWebMapper.java
+++ b/src/main/java/com/fastpay/presentation/mapper/PixWebMapper.java
@@ -1,4 +1,17 @@
 package com.fastpay.presentation.mapper;
 
-public class PixWebMapper {
+import com.fastpay.domain.model.PixKey;
+import com.fastpay.domain.model.Transaction;
+import com.fastpay.presentation.controller.response.PixKeyResponse;
+import com.fastpay.presentation.controller.response.TransferResponse;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface PixWebMapper {
+    PixKeyResponse toResponse(PixKey domain);
+
+    @Mapping(source = "id", target = "transactionId")
+    TransferResponse toResponse(Transaction domain);
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,22 @@
 spring:
   application:
     name: fastpay
+
+  datasource:
+    url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+    username: ${POSTGRES_USER}
+    password: ${POSTGRES_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    show-sql: true
+    open-in-view: true
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+
+springdoc:
+  swagger-ui:
+    path: /docs


### PR DESCRIPTION
## Description
This pull request introduces the complete flow for Pix key registration, adhering to Clean Architecture principles. It also includes critical infrastructure enhancements to ensure application stability and proper dependency injection mapping.

## Changes Included

### 1. Infrastructure & Build
- Added Docker healthchecks for PostgreSQL and Kafka (KRaft mode) in `docker-compose.yml` to guarantee proper service startup ordering.
- Created a multi-stage `Dockerfile` to optimize the application image build.
- Updated `build.gradle` to properly configure `mapstruct-processor` and `lombok-mapstruct-binding`, solving dependency injection issues for mappers.
- Configured database connections, JPA auto-ddl, and OpenAPI paths in `application.yml`.

### 2. Domain & Application Layers
- Defined input ports (`RegisterPixKeyUseCase`) and output ports (`AccountDatabasePort`, `PixKeyDatabasePort`).
- Implemented `RegisterPixKeyService` to handle core business logic, including account validation and checking for existing keys.
- Added business exceptions (`KeyNotFoundException`).

### 3. Persistence Layer (PostgreSQL)
- Created JPA entities (`UserEntity`, `AccountEntity`, `PixKeyEntity`) with proper relationship mappings.
- Created Spring Data repositories for Accounts and Pix Keys.
- Implemented MapStruct database mappers (`AccountDatabaseMapper`, `PixKeyDatabaseMapper`) to handle conversions between Domain Models and JPA Entities.
- Implemented the database adapters (`AccountPostgresAdapter`, `PixKeyPostgresAdapter`).

### 4. Presentation Layer (REST API)
- Implemented `PixKeyController` to expose the `/api/v1/keys` POST endpoint.
- Refactored DTOs (`PixKeyRequest`, `PixKeyResponse`) to use Java Records for immutability.
- Added Bean Validation (`@Valid`, `@NotNull`, `@NotBlank`) to the request layer.
- Implemented the MapStruct web mapper (`PixWebMapper`).

## Related Issues
Resolves #4, resolves #5, resolves #6, resolves #7
