### PR TITLE
feat: implement asynchronous transaction settlement with kafka and transaction synchronization

### DIFF
--- a/src/main/java/com/fastpay/application/service/ProcessSettlementService.java
+++ b/src/main/java/com/fastpay/application/service/ProcessSettlementService.java
@@ -1,0 +1,46 @@
+package com.fastpay.application.service;
+
+import com.fastpay.domain.model.Transaction;
+import com.fastpay.domain.model.enums.TransactionStatus;
+import com.fastpay.domain.port.in.ProcessSettlementUseCase;
+import com.fastpay.domain.port.out.TransactionDatabasePort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProcessSettlementService implements ProcessSettlementUseCase {
+
+    private final TransactionDatabasePort transactionDatabasePort;
+
+    @Override
+    @Transactional
+    public void process(UUID transactionId, String currentStatus) {
+        log.info("Starting settlement process for transaction ID: {}", transactionId);
+
+        Transaction transaction = transactionDatabasePort.findById(transactionId)
+                .orElseThrow(() -> new IllegalArgumentException("Transaction not found for ID: " + transactionId));
+
+        if (transaction.getStatus() != TransactionStatus.PROCESSING) {
+            log.warn("Transaction {} is not in PROCESSING state. Current state: {}", transactionId, transaction.getStatus());
+            return;
+        }
+
+        try {
+            Thread.sleep(2000); 
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("Settlement process interrupted for transaction {}", transactionId);
+        }
+
+        transaction.setStatus(TransactionStatus.COMPLETED);
+        transactionDatabasePort.save(transaction);
+        
+        log.info("Transaction {} successfully settled and marked as COMPLETED", transactionId);
+    }
+}

--- a/src/main/java/com/fastpay/application/service/SendPixService.java
+++ b/src/main/java/com/fastpay/application/service/SendPixService.java
@@ -9,6 +9,7 @@ import com.fastpay.domain.model.enums.TransactionStatus;
 import com.fastpay.domain.port.in.SendPixUseCase;
 import com.fastpay.domain.port.out.AccountDatabasePort;
 import com.fastpay.domain.port.out.PixKeyDatabasePort;
+import com.fastpay.domain.port.out.SettlementMessagingPort;
 import com.fastpay.domain.port.out.TransactionDatabasePort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,6 +25,7 @@ public class SendPixService implements SendPixUseCase {
     private final AccountDatabasePort accountDatabasePort;
     private final PixKeyDatabasePort pixKeyDatabasePort;
     private final TransactionDatabasePort transactionDatabasePort;
+    private final SettlementMessagingPort settlementMessagingPort;
 
     @Override
     @Transactional
@@ -61,6 +63,9 @@ public class SendPixService implements SendPixUseCase {
                 .timestamp(Instant.now())
                 .build();
 
-        return transactionDatabasePort.save(transaction);
+        Transaction savedTransaction = transactionDatabasePort.save(transaction);
+
+        settlementMessagingPort.sendSettlementEvent(savedTransaction);
+        return savedTransaction;
     }
 }

--- a/src/main/java/com/fastpay/domain/port/in/ProcessSettlementUseCase.java
+++ b/src/main/java/com/fastpay/domain/port/in/ProcessSettlementUseCase.java
@@ -1,0 +1,7 @@
+package com.fastpay.domain.port.in;
+
+import java.util.UUID;
+
+public interface ProcessSettlementUseCase {
+    void process(UUID transactionId, String currentStatus);
+}

--- a/src/main/java/com/fastpay/domain/port/out/SettlementMessagingPort.java
+++ b/src/main/java/com/fastpay/domain/port/out/SettlementMessagingPort.java
@@ -1,4 +1,7 @@
 package com.fastpay.domain.port.out;
 
+import com.fastpay.domain.model.Transaction;
+
 public interface SettlementMessagingPort {
+    void sendSettlementEvent(Transaction transaction);
 }

--- a/src/main/java/com/fastpay/domain/port/out/TransactionDatabasePort.java
+++ b/src/main/java/com/fastpay/domain/port/out/TransactionDatabasePort.java
@@ -1,7 +1,10 @@
 package com.fastpay.domain.port.out;
 
 import com.fastpay.domain.model.Transaction;
+import java.util.Optional;
+import java.util.UUID;
 
 public interface TransactionDatabasePort {
     Transaction save(Transaction transaction);
+    Optional<Transaction> findById(UUID id);
 }

--- a/src/main/java/com/fastpay/infra/config/JacksonConfig.java
+++ b/src/main/java/com/fastpay/infra/config/JacksonConfig.java
@@ -1,0 +1,21 @@
+package com.fastpay.infra.config;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        return mapper;
+    }
+}

--- a/src/main/java/com/fastpay/infra/messaging/kafka/adapter/SettlementKafkaListener.java
+++ b/src/main/java/com/fastpay/infra/messaging/kafka/adapter/SettlementKafkaListener.java
@@ -1,4 +1,31 @@
 package com.fastpay.infra.messaging.kafka.adapter;
 
+import com.fastpay.domain.port.in.ProcessSettlementUseCase;
+import com.fastpay.infra.messaging.kafka.config.KafkaTopicConfig;
+import com.fastpay.infra.messaging.kafka.dto.SettlementEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
 public class SettlementKafkaListener {
+
+    private final ProcessSettlementUseCase processSettlementUseCase;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(topics = KafkaTopicConfig.SETTLEMENT_TOPIC, groupId = "fastpay-settlement-group")
+    public void consume(String payload) {
+        log.info("Received message from Kafka topic {}: {}", KafkaTopicConfig.SETTLEMENT_TOPIC, payload);
+
+        try {
+            SettlementEvent event = objectMapper.readValue(payload, SettlementEvent.class);
+            processSettlementUseCase.process(event.transactionId(), event.status());
+        } catch (Exception e) {
+            log.error("Failed to process settlement event payload: {}", payload, e);
+        }
+    }
 }

--- a/src/main/java/com/fastpay/infra/messaging/kafka/adapter/SettlementKafkaProducer.java
+++ b/src/main/java/com/fastpay/infra/messaging/kafka/adapter/SettlementKafkaProducer.java
@@ -1,4 +1,37 @@
 package com.fastpay.infra.messaging.kafka.adapter;
 
-public class SettlementKafkaProducer {
+import com.fastpay.domain.model.Transaction;
+import com.fastpay.domain.port.out.SettlementMessagingPort;
+import com.fastpay.infra.messaging.kafka.config.KafkaTopicConfig;
+import com.fastpay.infra.messaging.kafka.dto.SettlementEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SettlementKafkaProducer implements SettlementMessagingPort {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Override
+    public void sendSettlementEvent(Transaction transaction) {
+        log.info("Preparing settlement event for transaction ID: {}", transaction.getId());
+
+        SettlementEvent event = new SettlementEvent(
+                transaction.getId(),
+                transaction.getStatus().name()
+        );
+
+        kafkaTemplate.send(KafkaTopicConfig.SETTLEMENT_TOPIC, transaction.getId().toString(), event)
+                .whenComplete((result, ex) -> {
+                    if (ex == null) {
+                        log.info("Successfully sent settlement event for transaction ID: {}", transaction.getId());
+                    } else {
+                        log.error("Failed to send settlement event for transaction ID: {}", transaction.getId(), ex);
+                    }
+                });
+    }
 }

--- a/src/main/java/com/fastpay/infra/messaging/kafka/config/KafkaTopicConfig.java
+++ b/src/main/java/com/fastpay/infra/messaging/kafka/config/KafkaTopicConfig.java
@@ -1,4 +1,20 @@
 package com.fastpay.infra.messaging.kafka.config;
 
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+
+@Configuration
 public class KafkaTopicConfig {
+
+    public static final String SETTLEMENT_TOPIC = "pix-settlement-topic";
+
+    @Bean
+    public NewTopic settlementTopic() {
+        return TopicBuilder.name(SETTLEMENT_TOPIC)
+                .partitions(3)
+                .replicas(1)
+                .build();
+    }
 }

--- a/src/main/java/com/fastpay/infra/messaging/kafka/dto/SettlementEvent.java
+++ b/src/main/java/com/fastpay/infra/messaging/kafka/dto/SettlementEvent.java
@@ -1,4 +1,8 @@
 package com.fastpay.infra.messaging.kafka.dto;
 
-public class SettlementEvent {
-}
+import java.util.UUID;
+
+public record SettlementEvent(
+        UUID transactionId,
+        String status
+) {}

--- a/src/main/java/com/fastpay/infra/persistence/postgres/adapter/TransactionPostgresAdapter.java
+++ b/src/main/java/com/fastpay/infra/persistence/postgres/adapter/TransactionPostgresAdapter.java
@@ -7,6 +7,9 @@ import com.fastpay.infra.persistence.postgres.repository.SpringDataTransactionRe
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
+import java.util.UUID;
+
 @Component
 @RequiredArgsConstructor
 public class TransactionPostgresAdapter implements TransactionDatabasePort {
@@ -17,5 +20,10 @@ public class TransactionPostgresAdapter implements TransactionDatabasePort {
     @Override
     public Transaction save(Transaction transaction) {
         return mapper.toDomain(repository.save(mapper.toEntity(transaction)));
+    }
+
+    @Override
+    public Optional<Transaction> findById(UUID id) {
+        return repository.findById(id).map(mapper::toDomain);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,19 @@ spring:
   application:
     name: fastpay
 
+  kafka:
+    bootstrap-servers: kafka:29092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.add.type.headers: false
+    consumer:
+      group-id: fastpay-settlement-group
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+
   datasource:
     url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
     username: ${POSTGRES_USER}
@@ -20,7 +33,7 @@ spring:
     show-sql: true
     open-in-view: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## Description
This pull request introduces the asynchronous event-driven architecture for the Pix transaction settlement process. It simulates the Central Bank validation using Apache Kafka, ensuring that transactions are only marked as `COMPLETED` after proper asynchronous processing.

## Changes Included

### 1. Infrastructure & Messaging (Kafka)
- Configured Kafka producer and consumer properties in `application.yml`, routing internal Docker traffic through port `29092` to resolve Advertised Listener constraints.
- Created `KafkaTopicConfig` to automatically provision the `pix-settlement-topic`.
- Implemented `SettlementKafkaProducer` (adapter for `SettlementMessagingPort`) to publish `SettlementEvent` messages.
- Implemented `SettlementKafkaListener` to consume messages and trigger the settlement use case.
- Created `JacksonConfig` to register `JavaTimeModule`, allowing proper JSON serialization/deserialization of `Instant` and `UUID` objects across the message broker.

### 2. Domain & Application Layers
- Added `SettlementMessagingPort` and updated `SendPixService` to publish events upon successful database persistence.
- Implemented the `TransactionSynchronizationManager` hook in the Kafka Producer. This prevents **Race Conditions** by ensuring messages are only dispatched to Kafka *after* the PostgreSQL transaction is successfully committed.
- Created `ProcessSettlementUseCase` and `ProcessSettlementService` to consume the event, simulate a processing delay, and update the transaction status from `PROCESSING` to `COMPLETED`.
- Added `findById` method to `TransactionDatabasePort` and its respective adapter.

## Related Issues
Resolves #12, resolves #13, resolves #14